### PR TITLE
Timeout support added

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,22 @@
+import unittest
+import envoy
+
+class SimpleTest(unittest.TestCase):
+    
+    def testInput(self):
+        r = envoy.run("sed s/i/I/g", "Hi")
+        self.assertEqual(r.std_out, "HI")
+        self.assertEqual(r.status_code, 0)
+    
+    def testPipe(self):
+        r = envoy.run("echo -n 'hi'| tr [:lower:] [:upper:]")
+        self.assertEqual(r.std_out, "HI")
+        self.assertEqual(r.status_code, 0)
+
+    def testTimeout(self):
+        r = envoy.run("yes | head", timeout=1)
+        self.assertEqual(r.std_out, 'y\ny\ny\ny\ny\ny\ny\ny\ny\ny\n')
+        self.assertEqual(r.status_code, 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi, I have add Timeout support. 

It is not being done the way you proposed in #2 but it does the job and should fix #2 and #5 as well.

The only problem I see is that the same timeout is used on each command. So for example

```
>>> envoy.run("sleep 5 | sleep 5", timeout = 3)
```

will take 6 seconds to execute.

Please comment on what is your opinion on this.

Thanks.

mrShu
