### PR TITLE
Fix ConnectedCommand.status_code

### DIFF
--- a/envoy/core.py
+++ b/envoy/core.py
@@ -71,6 +71,7 @@ class ConnectedCommand(object):
         self.std_in = std_in
         self.std_out = std_out
         self.std_err = std_out
+        self._status_code = None
 
     def __enter__(self):
         return self
@@ -83,11 +84,7 @@ class ConnectedCommand(object):
         """The status code of the process.
         If the code is None, assume that it's still running.
         """
-        if self._status_code is not None:
-            return self._status_code
-
-        # investigate
-        return None
+        return self._status_code
 
     @property
     def pid(self):

--- a/test_envoy.py
+++ b/test_envoy.py
@@ -24,5 +24,11 @@ class SimpleTest(unittest.TestCase):
         self.assertEqual(r.std_out.rstrip(), sentinel)
         self.assertEqual(r.status_code, 0)
 
+class ConnectedCommandTests(unittest.TestCase):
+
+    def test_status_code(self):
+        c = envoy.connect("sleep 5")
+        self.assertEqual(c.status_code, None)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Calling `status_code` on a `ConnectedCommand` which has not finished should return `None`, but it currently raises. This pull request fixes that.
### Before

```
>>> c = envoy.connect("sleep 5")
>>> repr(c.status_code)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "envoy/core.py", line 87, in status_code
    if self._status_code is not None:
AttributeError: 'ConnectedCommand' object has no attribute '_status_code'
```
### After

```
>>> c = envoy.connect("sleep 5")
>>> repr(c.status_code)
'None'
```
