### PR TITLE
Removed special bytes conversion for Python 3

### DIFF
--- a/envoy/core.py
+++ b/envoy/core.py
@@ -70,13 +70,7 @@ class Command(object):
                     bufsize=0,
                     cwd=cwd,
                 )
-
-                if sys.version_info[0] >= 3:
-                    self.out, self.err = self.process.communicate(
-                        input = bytes(self.data, "UTF-8") if self.data else None 
-                    )
-                else:
-                    self.out, self.err = self.process.communicate(self.data)
+                self.out, self.err = self.process.communicate(self.data)
             except Exception as exc:
                 self.exc = exc
               


### PR DESCRIPTION
With the current Python (3.3.0), this conversion to bytes in the run method before sending data to the subprocess module resulted in

AttributeError: 'bytes' object has no attribute 'encode'

in subprocess. Without the extra conversion, the run method performs smoothly in Python 3.3.0. The change should not effect Python 2 behavior, as the conversion was only triggered for Python 3 in the first place.
