### PR TITLE
Use basestring instead of str for type check.

### DIFF
--- a/envoy/core.py
+++ b/envoy/core.py
@@ -172,7 +172,7 @@ def expand_args(command):
     """Parses command strings and returns a Popen-ready list."""
 
     # Prepare arguments.
-    if isinstance(command, str):
+    if isinstance(command, basestring):
         splitter = shlex.shlex(command)
         splitter.whitespace = '|'
         splitter.whitespace_split = True


### PR DESCRIPTION
This avoids odd behaviour if a unicode string is passed into
`envoy.run` where the command isn't split for subprocess.
