### PR TITLE
Fix comment about pipe size restriction

### DIFF
--- a/envoy/core.py
+++ b/envoy/core.py
@@ -202,7 +202,7 @@ def run(command, data=None, timeout=None, kill_timeout=None, env=None, cwd=None)
     for c in command:
 
         if len(history):
-            # due to broken pipe problems pass only first 10MB
+            # due to broken pipe problems pass only first 10 KiB
             data = history[-1].std_out[0:10*1024]
 
         cmd = Command(c)


### PR DESCRIPTION
Pipe output is restricted to 10 _kilobytes_, not 10 megabytes as the comment currently states.

I suggest the better fix is to increase the pipe to 10 megabytes as per https://github.com/kennethreitz/envoy/pull/45 but if you don't want to change the code behaviour, at least merge this one so the code and comments agree.
