### PR TITLE
Real pipe support

### DIFF
--- a/envoy/core.py
+++ b/envoy/core.py
@@ -174,7 +174,7 @@ def expand_args(command):
     """Parses command strings and returns a Popen-ready list."""
 
     # Prepare arguments.
-    if isinstance(command, str):
+    if isinstance(command, basestring):
         splitter = shlex.shlex(command, posix=True)
         splitter.quotes = ''
         splitter.whitespace = '|'


### PR DESCRIPTION
Envoy was faking pipes by launching commands, saving its output and passing it to the next command.
This caused broken pipes problems apart from useless memory usage. The workaround for broken pipes issues limited the pipe data to 10kb.

I changed the behavior of envoy by passing process.stdout as stdin of the next process. This solution unfortunately doesn't allow to get stderr of a process that is not the last one. Any ideas about how to achieve this?
