### PR TITLE
Add folders generated by `setup.py sdist` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+dist/
+envoy.egg-info/
 *.pyc


### PR DESCRIPTION
Running `python setup sdist` generates some folders in the
working directory.  Add these to the .gitignore file.
