### PR TITLE
allow for unicode in commands

### DIFF
--- a/envoy/core.py
+++ b/envoy/core.py
@@ -172,8 +172,8 @@ def expand_args(command):
     """Parses command strings and returns a Popen-ready list."""
 
     # Prepare arguments.
-    if isinstance(command, str):
-        splitter = shlex.shlex(command)
+    if isinstance(command, (str, unicode)):
+        splitter = shlex.shlex(command.encode('utf-8'))
         splitter.whitespace = '|'
         splitter.whitespace_split = True
         command = []


### PR DESCRIPTION
Fix handling of commands or arguments containing unicode. Apparently this is a known problem with `shlex.split()`, I got the fix from [this comment on Stack Overflow](http://stackoverflow.com/a/14219159/973044).

Disclaimer: It seems to work ok, but I'm no expert on unicode, and testing has been limited to my environment.
