### PR TITLE
Add flag to show cmd input/output

### DIFF
--- a/envoy/core.py
+++ b/envoy/core.py
@@ -15,7 +15,7 @@ import subprocess
 import threading
 
 from clint.textui import puts, indent
-from clint.textui.colored import red, blue
+from clint.textui.colored import red, blue, cyan
 
 
 __version__ = '0.0.2'

--- a/envoy/core.py
+++ b/envoy/core.py
@@ -199,17 +199,21 @@ def run(command, data=None, timeout=None, kill_timeout=None, env=None, cwd=None,
     Blocks until process is complete, or timeout is reached.
     """
 
+    if show:
+        puts(cyan(command))
+
     command = expand_args(command)
 
     history = []
     for c in command:
-        
-        if show:
-            puts(blue(c))
 
         if len(history):
             # due to broken pipe problems pass only first 10 KiB
             data = history[-1].std_out[0:10*1024]
+
+        if show and len(command) > 1:
+            with indent(2):
+                puts(blue(str(c)))
 
         cmd = Command(c)
         out, err = cmd.run(data, timeout, kill_timeout, env, cwd)
@@ -220,7 +224,7 @@ def run(command, data=None, timeout=None, kill_timeout=None, env=None, cwd=None,
         r.std_out = out
         r.std_err = err
         r.status_code = cmd.returncode
-        
+
         if show:
             with indent(4):
                 puts(r.std_out)

--- a/envoy/core.py
+++ b/envoy/core.py
@@ -14,6 +14,9 @@ import signal
 import subprocess
 import threading
 
+from clint.textui import puts, indent
+from clint.textui.colored import red, blue
+
 
 __version__ = '0.0.2'
 __license__ = 'MIT'
@@ -190,7 +193,7 @@ def expand_args(command):
     return command
 
 
-def run(command, data=None, timeout=None, kill_timeout=None, env=None, cwd=None):
+def run(command, data=None, timeout=None, kill_timeout=None, env=None, cwd=None, show=False):
     """Executes a given commmand and returns Response.
 
     Blocks until process is complete, or timeout is reached.
@@ -200,6 +203,9 @@ def run(command, data=None, timeout=None, kill_timeout=None, env=None, cwd=None)
 
     history = []
     for c in command:
+        
+        if show:
+            puts(blue(c))
 
         if len(history):
             # due to broken pipe problems pass only first 10 KiB
@@ -214,6 +220,13 @@ def run(command, data=None, timeout=None, kill_timeout=None, env=None, cwd=None)
         r.std_out = out
         r.std_err = err
         r.status_code = cmd.returncode
+        
+        if show:
+            with indent(4):
+                puts(r.std_out)
+                if r.status_code != 0:
+                    puts(red('Status Code: {}'.format(r.status_code)))
+                puts(red(r.std_err))
 
         history.append(r)
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ if sys.argv[-1] == "publish":
     os.system("python setup.py sdist upload")
     sys.exit()
 
-required = []
+required = [
+    # TODO: add required version(s)
+    "clint"
+]
 
 setup(
     name='envoy',


### PR DESCRIPTION
I personally found myself wanting to see exactly what commands where being run, and what their output was, using [clint](http://github.com/kennethreitz/clint). I was constantly repeating myself (print command, run command, print output and return code).

This lead to me abandoning use of envoy in favor of a pattern like [this](https://gist.github.com/rattrayalex/57bd40b2de7f8868d25f). Needless to say, copying this into every file was getting to be a chore, but it didn't seem like "enough" to warrant its own library. 

If this seems like a worthwhile addition, please take it. Otherwise, would love advice from others on how best to release. 

This is my first pull request to open source that I'm aware of, so please let me know if I'm deficient/out of line in any way here!